### PR TITLE
Plugin Normalizer option: make filename lowercase

### DIFF
--- a/php/plugins/Normalizer/plugin.php
+++ b/php/plugins/Normalizer/plugin.php
@@ -24,7 +24,8 @@
  *			'Normalizer' => array(
  *				'enable' => true,
  *				'nfc'    => true,
- *				'nfkc'   => true
+ *				'nfkc'   => true,
+ *				'lowercase'   => false
  *			)
  *		),
  *		// each volume configure (optional)
@@ -37,7 +38,8 @@
  *					'Normalizer' => array(
  *						'enable' => true,
  *						'nfc'    => true,
- *						'nfkc'   => true
+ *						'nfkc'   => true,
+ * 						'lowercase'   => false
  *					)
  *				)
  *			)
@@ -56,7 +58,8 @@ class elFinderPluginNormalizer
 		$defaults = array(
 			'enable' => true, // For control by volume driver
 			'nfc'    => true, // Canonical Decomposition followed by Canonical Composition
-			'nfkc'   => true  // Compatibility Decomposition followed by Canonical
+			'nfkc'   => true,  // Compatibility Decomposition followed by Canonical
+			'lowercase'   => false  // Make chars lowercase
 		);
 	
 		$this->opts = array_merge($defaults, $opts);
@@ -81,7 +84,8 @@ class elFinderPluginNormalizer
 		}
 		
 		if ($path) {
-			$path = $this->normalize($path, $opts);
+			$path_opts = array_merge($opts, array('lowercase'=>false));
+			$path = $this->normalize($path, $path_opts);
 		}
 		$name = $this->normalize($name, $opts);
 		return true;
@@ -115,6 +119,9 @@ class elFinderPluginNormalizer
 				if ($opts['nfkc'])
 					$str = $normalizer->normalize($str, 'NFKC');
 			}
+		}
+		if ($opts['lowercase']) {
+			$str = strtolower($str);
 		}
 		return $str;
 	}


### PR DESCRIPTION
I prefer making de filename lowercase always. I propose a pull request to have it build in the plugin code in that way, that the user can decide tot turn the option on or off.
Default: off.
See also: [#1140](https://github.com/Studio-42/elFinder/pull/1140)
